### PR TITLE
Changing facet configuration format; allow presenter logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ Add the hierarchy-specific options to the controller configuration
 
     config.facet_display = {
       :hierarchy => {
-        'queue_status' => [['facet'], ':']
+        'queue_status' => {
+          fields: ['facet'],
+          delimiter: ':'
+        }
       }
     }
 

--- a/lib/blacklight/hierarchy/version.rb
+++ b/lib/blacklight/hierarchy/version.rb
@@ -1,5 +1,5 @@
 module Blacklight
   module Hierarchy
-    VERSION = "0.1.1"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
Switching to a configuration hash instead of an array.
The new configuration method introduces a way to pass facet values through a presenter method.
This is needed for ndlib/curate_nd#478
